### PR TITLE
Display representative totals for party constellations

### DIFF
--- a/css/party-constellations.css
+++ b/css/party-constellations.css
@@ -153,6 +153,22 @@
 }
 /* *** SLUTT PÅ ENDRING *** */
 
+.constellation-seat-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    border-radius: 16px;
+    background: linear-gradient(135deg, rgba(0, 95, 171, 0.15), rgba(0, 95, 171, 0.05));
+    color: #004a85;
+    font-size: 0.95rem;
+    border: 1px solid rgba(0, 95, 171, 0.25);
+}
+
+.constellation-seat-badge strong {
+    font-size: 1.05rem;
+}
+
 .issue-category-group {
     border: 1px solid #e0e0e0;
     border-radius: 8px;

--- a/js/party-constellations.js
+++ b/js/party-constellations.js
@@ -137,6 +137,11 @@ document.addEventListener('DOMContentLoaded', () => {
         const header = document.createElement('div');
         header.className = 'constellation-header';
 
+        const seatCount = combo.reduce((total, shorthand) => {
+            const partyInfo = parties.find(p => p.shorthand === shorthand);
+            return partyInfo ? total + (partyInfo.seats || 0) : total;
+        }, 0);
+
         // *** START PÅ ENDRING ***
         combo.forEach(shorthand => {
             const partyInfo = parties.find(p => p.shorthand === shorthand);
@@ -163,6 +168,11 @@ document.addEventListener('DOMContentLoaded', () => {
             header.appendChild(tag);
         });
         // *** SLUTT PÅ ENDRING ***
+
+        const seatBadge = document.createElement('div');
+        seatBadge.className = 'constellation-seat-badge';
+        seatBadge.innerHTML = `<strong>${seatCount}</strong> representanter`;
+        header.appendChild(seatBadge);
 
         const agreementText = document.createElement('span');
         agreementText.textContent = ` er enige om ${issues.length} sak${issues.length > 1 ? 'er' : ''}:`;


### PR DESCRIPTION
## Summary
- compute total parliamentary seats for each selected party constellation from parties.json
- add a seat count badge to constellation headers and style it for emphasis

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e413a54240832ea0c28f017db7366b