### PR TITLE
Add profile avatars to party representative cards

### DIFF
--- a/css/candidates.css
+++ b/css/candidates.css
@@ -178,7 +178,8 @@
 .candidate-card::before { content: ''; display: block; height: 6px; background-color: var(--party-color); background-image: none; margin-bottom: 10px; }
 .candidate-card.party-sv::before { background-image: linear-gradient(to right, #439539, #eb2e2d); background-color: transparent; }
 .candidate-card:hover { transform: translateY(-4px); box-shadow: 0 6px 15px rgba(0,0,0,0.1); border-color: #bbb; }
-.candidate-card .card-header { display: flex; align-items: flex-start; padding: 0 15px 8px 15px; border-bottom: 1px solid #f0f0f0; gap: 10px; }
+.candidate-card .card-header { display: flex; align-items: center; padding: 0 15px 8px 15px; border-bottom: 1px solid #f0f0f0; gap: 12px; }
+.candidate-card .candidate-avatar { width: 52px; height: 52px; border-radius: 50%; object-fit: cover; border: 2px solid #fff; box-shadow: 0 2px 6px rgba(0,0,0,0.15); background-color: #f2f4f8; flex-shrink: 0; }
 .candidate-card .candidate-rank { font-size: 1.6rem; font-weight: bold; color: var(--party-color); line-height: 1.2; padding-top: 2px; min-width: 30px; text-align: center; }
 .candidate-card .candidate-header-info { flex-grow: 1; display: flex; flex-direction: column; }
 .candidate-card .candidate-name { font-size: 1.1rem; font-weight: 600; color: #333; line-height: 1.3; margin-bottom: 2px; }

--- a/js/party-profile.js
+++ b/js/party-profile.js
@@ -280,16 +280,24 @@ document.addEventListener('DOMContentLoaded', function() {
      }
 
      function createRepresentativeCard(representative, partyInfo) {
-         const safePartyInfo = partyInfo || partiesMap[representative.partyShorthand] || {};
-         const shorthand = safePartyInfo.shorthand || representative.partyShorthand || '';
-         const partyClassPrefix = safePartyInfo.classPrefix || shorthand.toLowerCase() || 'ukjent';
-         const card = document.createElement('div');
-         card.className = `candidate-card party-${partyClassPrefix}`;
-         card.style.setProperty('--party-color', safePartyInfo.color || '#ccc');
-         card.dataset.representativeInfo = JSON.stringify(representative);
-         card.innerHTML = `
+        const safePartyInfo = partyInfo || partiesMap[representative.partyShorthand] || {};
+        const shorthand = safePartyInfo.shorthand || representative.partyShorthand || '';
+        const normalizedShorthand = (shorthand || '').toLowerCase();
+        const partyClassPrefix = safePartyInfo.classPrefix || normalizedShorthand || 'ukjent';
+        const placeholderPath = shorthand
+            ? `images/candidates/placeholder-${normalizedShorthand}.png`
+            : 'images/placeholder-generic.png';
+        const imageUrl = representative.imageUrl || placeholderPath;
+        const card = document.createElement('div');
+        card.className = `candidate-card party-${partyClassPrefix}`;
+        card.style.setProperty('--party-color', safePartyInfo.color || '#ccc');
+        card.dataset.representativeInfo = JSON.stringify(representative);
+        card.innerHTML = `
             <div class="card-header">
-                <span class="candidate-name">${representative.name || 'Ukjent navn'}</span>
+                <img src="${imageUrl}" alt="Profilbilde av ${representative.name || 'representant'}" class="candidate-avatar" onerror="this.onerror=null; this.src='${placeholderPath}';">
+                <div class="candidate-header-info">
+                    <span class="candidate-name">${representative.name || 'Ukjent navn'}</span>
+                </div>
                 <div class="party-icon icon-${partyClassPrefix}" style="background-color:${safePartyInfo.color || '#ccc'}" title="${safePartyInfo.name || representative.partyShorthand || '?'}">${(shorthand || '?').charAt(0) || '?'}</div>
             </div>
             <div class="card-body">


### PR DESCRIPTION
## Summary
- show each representative's thumbnail directly in the party profile cards with placeholder fallback images
- adjust candidate card styling to accommodate the new avatar presentation

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e4b49ab278832ea66c3b7ae0057d4f