### PR TITLE
Load party overview seats from parties.json

### DIFF
--- a/css/party-overview.css
+++ b/css/party-overview.css
@@ -54,13 +54,41 @@
 }
 
 .party-seat-count {
-    margin-left: auto;
-    background-color: rgba(0, 48, 135, 0.1);
-    padding: 5px 10px;
-    border-radius: 20px;
-    font-size: 0.9rem;
-    font-weight: bold;
+    margin-top: 6px;
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 0.95rem;
+    font-weight: 600;
     color: var(--kf-blue);
+    flex-wrap: wrap;
+}
+
+.seat-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 12px;
+    border-radius: 999px;
+    background: linear-gradient(135deg, rgba(0, 122, 200, 0.15), rgba(0, 122, 200, 0.05));
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+    color: var(--kf-blue);
+}
+
+.seat-icon {
+    font-size: 1rem;
+}
+
+.seat-number {
+    font-size: 1.1rem;
+    font-weight: 700;
+}
+
+.seat-label {
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #7a7a7a;
 }
 
 .party-stats {
@@ -360,18 +388,14 @@
 .party-info {
     display: flex;
     flex-direction: column;
+    gap: 6px;
+    align-items: flex-start;
 }
 
 .party-name {
     margin: 0;
     font-size: 1.25rem;
     font-weight: 700;
-}
-
-.party-seat-count {
-    margin: 0;
-    font-size: 0.9rem;
-    color: #666;
 }
 
 /* Gammel styling for statistikk og faner (beholdt fra din originale fil) */


### PR DESCRIPTION
## Summary
- load party metadata from parties.json before rendering the party overview so seat counts stay in sync with data
- add a polished seat badge design in the party cards while keeping the existing issue tabs behaviour

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4ba2c4454832eae2455f8e102ba44