### PR TITLE
Redesign party profile experience

### DIFF
--- a/css/party-profile.css
+++ b/css/party-profile.css
@@ -1,6 +1,197 @@
 /* css/party-profile.css (Version 2.2 - Fjerner konflikter for featured view) */
 
 /* Container for partivelger */
+.party-hero {
+    margin-top: 30px;
+}
+
+.party-hero-placeholder {
+    background: linear-gradient(135deg, #f6f9ff 0%, #eef2ff 100%);
+    border-radius: 22px;
+    padding: 32px;
+    text-align: center;
+    color: #506080;
+    box-shadow: 0 18px 45px rgba(24, 61, 116, 0.12);
+}
+
+.party-hero-card {
+    --party-color: var(--kf-blue);
+    --party-color-soft: rgba(13, 109, 253, 0.12);
+    --party-color-border: rgba(13, 109, 253, 0.24);
+    --party-color-strong: #0d6efd;
+    background: linear-gradient(140deg, rgba(255,255,255,0.96) 0%, rgba(255,255,255,0.88) 40%, rgba(255,255,255,0.82) 100%);
+    border-radius: 26px;
+    padding: 34px clamp(24px, 5vw, 48px);
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: clamp(20px, 4vw, 40px);
+    align-items: center;
+    box-shadow: 0 24px 55px rgba(13, 45, 94, 0.18);
+    position: relative;
+    overflow: hidden;
+}
+
+.party-hero-card::after {
+    content: "";
+    position: absolute;
+    inset: -40% auto auto -40%;
+    width: 220px;
+    height: 220px;
+    background: radial-gradient(circle at center, rgba(255,255,255,0.55) 0%, rgba(255,255,255,0) 70%);
+    opacity: 0.9;
+}
+
+.party-hero-card::before {
+    content: "";
+    position: absolute;
+    inset: auto -35% -60% auto;
+    width: 260px;
+    height: 260px;
+    background: radial-gradient(circle at center, rgba(0,0,0,0.08) 0%, rgba(0,0,0,0) 70%);
+    opacity: 0.7;
+}
+
+.party-hero-logo {
+    position: relative;
+    z-index: 1;
+    width: clamp(84px, 12vw, 120px);
+    aspect-ratio: 1 / 1;
+    border-radius: 24px;
+    background: linear-gradient(145deg, rgba(255,255,255,0.8), rgba(255,255,255,0.4));
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 18px 38px rgba(13, 45, 94, 0.16);
+    border: 1px solid rgba(255,255,255,0.75);
+}
+
+.party-hero-logo img {
+    max-width: 70%;
+    height: auto;
+}
+
+.party-hero-details {
+    position: relative;
+    z-index: 1;
+    display: grid;
+    gap: 10px;
+    color: #1f2d46;
+}
+
+.party-hero-title {
+    margin: 0;
+    font-size: clamp(1.8rem, 3vw, 2.4rem);
+    font-weight: 700;
+    color: #0f2343;
+}
+
+.party-hero-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-top: 4px;
+}
+
+.party-hero-pill {
+    background: rgba(13, 109, 253, 0.08);
+    border: 1px solid rgba(13, 109, 253, 0.18);
+    color: #0d6efd;
+    font-weight: 600;
+    padding: 6px 14px;
+    border-radius: 999px;
+    font-size: 0.9rem;
+}
+
+.party-hero-pill.accent {
+    background: var(--party-color-soft);
+    border-color: var(--party-color-border);
+    color: var(--party-color-strong);
+}
+
+.party-hero-summary {
+    margin: 0;
+    color: #42516d;
+    font-size: 1rem;
+    line-height: 1.5;
+}
+
+.party-selector-wrapper {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    margin-top: 30px;
+}
+
+.party-logo-banner {
+    display: none;
+    background: linear-gradient(135deg, rgba(255,255,255,0.95) 0%, rgba(247,250,255,0.95) 100%);
+    border-radius: 18px;
+    padding: 16px clamp(16px, 3vw, 28px);
+    box-shadow: 0 18px 45px rgba(15, 45, 92, 0.14);
+    gap: 12px;
+    overflow-x: auto;
+    align-items: center;
+}
+
+.party-logo-banner::-webkit-scrollbar {
+    height: 8px;
+}
+
+.party-logo-banner::-webkit-scrollbar-thumb {
+    background: rgba(15, 45, 92, 0.2);
+    border-radius: 999px;
+}
+
+.party-logo-button {
+    border: none;
+    background: transparent;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 10px 14px;
+    border-radius: 16px;
+    gap: 8px;
+    cursor: pointer;
+    transition: transform 0.25s ease, box-shadow 0.25s ease, background 0.25s ease;
+    min-width: 92px;
+    position: relative;
+}
+
+.party-logo-button:focus-visible {
+    outline: 3px solid rgba(13, 109, 253, 0.35);
+    outline-offset: 4px;
+}
+
+.party-logo-button img {
+    width: 46px;
+    height: 46px;
+    object-fit: contain;
+    filter: drop-shadow(0 4px 6px rgba(15, 45, 92, 0.16));
+    transition: transform 0.25s ease;
+}
+
+.party-logo-button span {
+    font-weight: 600;
+    color: #32415e;
+    font-size: 0.85rem;
+    letter-spacing: 0.02em;
+}
+
+.party-logo-button:hover {
+    transform: translateY(-4px);
+    background: rgba(13, 109, 253, 0.08);
+}
+
+.party-logo-button.selected {
+    background: linear-gradient(140deg, rgba(13, 109, 253, 0.12), rgba(13, 109, 253, 0.22));
+    box-shadow: 0 18px 35px rgba(13, 45, 94, 0.18);
+}
+
+.party-logo-button.selected img {
+    transform: scale(1.08);
+}
+
 .party-selector-profile {
     background-color: white;
     padding: 20px;
@@ -37,9 +228,10 @@
 
 /* Stil for hver boks i rutenettet */
 .profile-box {
-    background-color: white;
-    border-radius: 12px;
-    box-shadow: 0 4px 15px rgba(0,0,0,0.06);
+    background: linear-gradient(160deg, rgba(255,255,255,0.96), rgba(245,250,255,0.92));
+    border-radius: 22px;
+    box-shadow: 0 26px 55px rgba(13, 45, 94, 0.12);
+    border: 1px solid rgba(13, 45, 94, 0.05);
     padding: 0; /* Padding settes på inner-content */
     display: flex; /* Bruker flex for å håndtere inner-content */
     flex-direction: column;
@@ -48,7 +240,7 @@
 }
 
 .profile-inner-content {
-    padding: 25px;
+    padding: clamp(22px, 3vw, 28px);
     flex-grow: 1; /* Tar tilgjengelig plass */
     display: flex;
     flex-direction: column;
@@ -89,6 +281,36 @@
     color: #888;
     margin: auto; /* Sentrerer i flex container */
 }
+
+.chart-container {
+    background: linear-gradient(145deg, rgba(255,255,255,0.92) 0%, rgba(235,242,255,0.92) 100%);
+    border-radius: 18px;
+    padding: clamp(18px, 4vw, 26px);
+    box-shadow: inset 0 1px 0 rgba(255,255,255,0.6);
+    position: relative;
+    overflow: hidden;
+}
+
+.chart-container::after {
+    content: "";
+    position: absolute;
+    inset: auto -30% -40% auto;
+    width: 220px;
+    height: 220px;
+    background: radial-gradient(circle at center, rgba(13, 109, 253, 0.12) 0%, rgba(13, 109, 253, 0) 70%);
+    pointer-events: none;
+}
+
+.chart-container h3 {
+    margin-top: 0;
+    margin-bottom: 16px;
+    color: #16315c;
+}
+
+.chart-surface {
+    width: 100%;
+    min-height: 260px;
+}
 .profile-box .loader.error p {
     color: var(--fail-color);
     font-weight: bold;
@@ -117,6 +339,31 @@
         position: relative; /* Tilbake til normal flyt */
         height: 200px; /* Gi litt fast høyde */
         margin-bottom: 20px;
+    }
+}
+
+@media (max-width: 768px) {
+    .party-hero-card {
+        grid-template-columns: 1fr;
+        text-align: center;
+    }
+
+    .party-hero-logo {
+        margin: 0 auto;
+    }
+
+    .party-hero-meta {
+        justify-content: center;
+    }
+}
+
+@media (min-width: 992px) {
+    .party-logo-banner {
+        display: flex;
+    }
+
+    .party-selector-profile {
+        display: none;
     }
 }
 /* ===== SLUTT: 2x2 Grid Layout ===== */

--- a/party-profile.html
+++ b/party-profile.html
@@ -36,11 +36,20 @@
             <div class="nav-links"></div>
         </header>
 
-        <div class="party-selector-profile">
-            <label for="party-select">Velg parti for å se detaljert profil:</label>
-            <select id="party-select" class="filter-dropdown">
-                <option value="">Velg parti...</option>
-                </select>
+        <section class="party-hero" id="party-hero" aria-live="polite">
+            <div class="party-hero-placeholder">
+                <p>Velg et parti for å låse opp en skreddersydd profil.</p>
+            </div>
+        </section>
+
+        <div class="party-selector-wrapper">
+            <div class="party-logo-banner" id="party-logo-banner" aria-label="Tilgjengelige partier"></div>
+            <div class="party-selector-profile">
+                <label for="party-select">Velg parti for å se detaljert profil:</label>
+                <select id="party-select" class="filter-dropdown">
+                    <option value="">Velg parti...</option>
+                    </select>
+            </div>
         </div>
 
         <main id="profile-content" class="profile-content-grid">


### PR DESCRIPTION
## Summary
- add a hero section with dynamic party highlights and a desktop logo banner selector
- refresh party profile styling with layered surfaces and updated chart containers for more visual depth
- retheme the Plotly charts to match party colors and surface clearer context values

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68e4ea1f4fac832ea9e8dcbe11be0ddf