### PR TITLE
Add navigation from issue matrix logos to party profiles

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1361,6 +1361,23 @@ header {
     padding: 2px 0; /* Litt vertikal luft */
 }
 
+.matrix-header-link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    border-radius: 8px;
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.matrix-header-link:hover,
+.matrix-header-link:focus-visible {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.12);
+    outline: none;
+}
+
 /* 3. Justerer SUM-headeren for konsistens */
 .matrix-table thead th.party-col[title="Sum av poeng"] {
     color: #555 !important;

--- a/js/issue-matrix.js
+++ b/js/issue-matrix.js
@@ -399,8 +399,11 @@ function generateMatrix(areaFilter, viewMode) {
         partyHeader.title = party.name;
         
         // === ENDRING: Byttet ut header-innhold med kun logoen ===
+        const profileUrl = `party-profile.html?party=${encodeURIComponent(party.shorthand)}`;
         partyHeader.innerHTML = `
-            <img src="images/parties/${party.shorthand.toLowerCase()}.png" alt="${party.name}" class="matrix-header-logo">
+            <a href="${profileUrl}" class="matrix-header-link" aria-label="Gå til ${party.name} sin partiprofil">
+                <img src="images/parties/${party.shorthand.toLowerCase()}.png" alt="${party.name}" class="matrix-header-logo">
+            </a>
         `;
         // === SLUTT ENDRING ===
 

--- a/js/party-profile.js
+++ b/js/party-profile.js
@@ -53,6 +53,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
                 processInitialData();
                 initializeProfilePage();
+                applyInitialPartySelectionFromUrl();
             })
             .catch(error => {
                 console.error("Party Profile v2.3: Failed to load required data:", error);
@@ -100,6 +101,31 @@ document.addEventListener('DOMContentLoaded', function() {
         if (candidateGrid) { candidateGrid.addEventListener('click', handleRepresentativeCardClick); }
 
         console.log("Party Profile v2.3: Page initialized.");
+    }
+
+    function applyInitialPartySelectionFromUrl() {
+        if (!partySelect) return;
+        const params = new URLSearchParams(window.location.search);
+        const requestedParty = params.get('party');
+        if (!requestedParty) return;
+
+        const normalizedParty = requestedParty.trim().toLowerCase();
+        if (!normalizedParty) return;
+
+        const availablePartyKey = Object.keys(partiesMap).find(key => key.toLowerCase() === normalizedParty);
+        if (!availablePartyKey) {
+            console.warn(`Party Profile v2.3: Ingen parti med kode som matcher '${requestedParty}' ble funnet.`);
+            return;
+        }
+
+        const option = partySelect.querySelector(`option[value="${availablePartyKey}"]`);
+        if (!option) {
+            console.warn(`Party Profile v2.3: Partiet '${availablePartyKey}' er ikke tilgjengelig i listen (mangler data?).`);
+            return;
+        }
+
+        partySelect.value = availablePartyKey;
+        partySelect.dispatchEvent(new Event('change'));
     }
 
     loadAllData();


### PR DESCRIPTION
## Summary
- link each issue matrix header logo to the corresponding party profile page
- add hover and focus styling for the clickable header logos
- support pre-selecting a party on the profile page via the `party` URL parameter

## Testing
- browser_container.run_playwright_script (manual navigation check)


------
https://chatgpt.com/codex/tasks/task_e_68e4f4c7437c832ea7d1477dac02f360