### PR TITLE
Add clickable issue detail panel to issue matrix

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1008,6 +1008,45 @@ body.menu-open .burger-menu {
 }
 .matrix-table th.issue-col, .matrix-table td.issue-col { text-align: left; position: sticky; left: 0; background-color: white; z-index: 1; min-width: 250px; white-space: normal; border-right: 2px solid #ddd; }
 .matrix-table thead th.issue-col { z-index: 11; background-color: #f8f9fa; border-radius: 12px 0 0 12px; }
+.matrix-table .issue-name-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    width: 100%;
+    border: none;
+    background: none;
+    padding: 6px 0;
+    font: inherit;
+    color: inherit;
+    cursor: pointer;
+    text-align: left;
+}
+.matrix-table .issue-name-button:focus-visible {
+    outline: 3px solid var(--kf-blue);
+    outline-offset: 2px;
+    border-radius: 6px;
+}
+.matrix-table .issue-name-button .issue-name-text {
+    flex: 1;
+    font-weight: 600;
+}
+.matrix-table .issue-name-button .issue-open-indicator {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 26px;
+    height: 26px;
+    border-radius: 50%;
+    background-color: rgba(0, 48, 135, 0.08);
+    color: var(--kf-blue);
+    font-size: 0.8rem;
+    transition: transform 0.2s ease;
+}
+.matrix-table .issue-name-button:hover .issue-open-indicator,
+.matrix-table .issue-name-button:focus-visible .issue-open-indicator {
+    transform: scale(1.1);
+}
 .matrix-table tbody tr:not(.area-header):nth-child(even) td {
      background-color: #f8f9fa;
 }
@@ -1074,6 +1113,163 @@ body.menu-open .burger-menu {
 .sum-cell-content { display: inline-flex; align-items: center; justify-content: center; width: 70px; height: 36px; border-radius: 24px; font-weight: bold; font-size: 1rem; border: 1px solid transparent; box-sizing: border-box; cursor: default; }
 .matrix-tooltip { display: none; position: absolute; z-index: 1000; background-color: white; box-shadow: 0 4px 20px rgba(0,0,0,0.15); border-radius: 8px; padding: 15px 20px; max-width: 350px; font-size: 0.95rem; line-height: 1.5; border-left: 4px solid var(--kf-purple); }
 .matrix-loader { text-align: center; padding: 50px; font-size: 1.2rem; color: #666; }
+
+/* ------ Detaljpanel for saksinformasjon (gjenbrukbar stil) ------ */
+.panel-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    z-index: 1090;
+    opacity: 0;
+    transition: opacity 0.3s ease-in-out;
+    pointer-events: none;
+}
+.panel-overlay.active {
+    opacity: 1;
+    pointer-events: auto;
+}
+.detail-panel {
+    position: fixed;
+    top: 0;
+    right: -460px;
+    width: 460px;
+    max-width: 92vw;
+    height: 100%;
+    background-color: white;
+    box-shadow: -5px 0 20px rgba(0,0,0,0.15);
+    z-index: 1100;
+    transition: right 0.4s cubic-bezier(0.25, 0.8, 0.25, 1);
+    display: flex;
+    flex-direction: column;
+}
+.detail-panel.active {
+    right: 0;
+}
+.panel-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 18px 28px;
+    border-bottom: 1px solid #eee;
+    flex-shrink: 0;
+}
+.panel-header h3 {
+    margin: 0;
+    font-size: 1.35rem;
+    color: var(--kf-blue);
+}
+.close-panel-btn {
+    background: none;
+    border: none;
+    font-size: 2.5rem;
+    line-height: 1;
+    color: #aaa;
+    cursor: pointer;
+    padding: 0 6px;
+    transition: color 0.2s ease;
+}
+.close-panel-btn:hover,
+.close-panel-btn:focus-visible {
+    color: #333;
+    outline: none;
+}
+.panel-content {
+    padding: 26px;
+    overflow-y: auto;
+    flex-grow: 1;
+}
+.panel-issue-area {
+    font-style: italic;
+    color: #666;
+    margin: 0 0 16px 0;
+}
+.panel-issue-description {
+    margin: 0 0 22px 0;
+    line-height: 1.6;
+    color: #444;
+}
+.stance-group {
+    margin-bottom: 28px;
+}
+.stance-group h4 {
+    margin: 0 0 12px 0;
+    padding-bottom: 8px;
+    font-size: 1rem;
+    font-weight: 600;
+    border-bottom: 2px solid;
+}
+.stance-group.level-2 h4 { color: #28a745; border-color: #28a745; }
+.stance-group.level-1 h4 { color: #ffc107; border-color: #ffc107; }
+.stance-group.level-0 h4 { color: #dc3545; border-color: #dc3545; }
+.stance-party-item {
+    display: flex;
+    gap: 14px;
+    padding: 12px 0;
+    border-bottom: 1px solid #f0f0f0;
+}
+.stance-party-item:last-child {
+    border-bottom: none;
+}
+.party-logo-link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+.stance-party-item .party-logo {
+    width: 40px;
+    height: 40px;
+    flex-shrink: 0;
+}
+.stance-party-item .party-details {
+    flex-grow: 1;
+}
+.stance-party-item .party-name {
+    font-weight: 600;
+    font-size: 1rem;
+    margin-bottom: 4px;
+}
+.stance-party-item .party-name a {
+    color: inherit;
+    text-decoration: none;
+}
+.stance-party-item .party-name a:hover,
+.stance-party-item .party-name a:focus-visible {
+    text-decoration: underline;
+}
+.stance-party-item .party-quote {
+    margin-top: 4px;
+    font-size: 0.9rem;
+    font-style: italic;
+    color: #555;
+    line-height: 1.5;
+    background-color: #f8f9fa;
+    padding: 9px 12px;
+    border-left: 3px solid #ddd;
+    border-radius: 4px;
+}
+.stance-party-item .party-quote.no-quote {
+    color: #999;
+}
+.panel-empty-state {
+    text-align: center;
+    color: #777;
+    font-style: italic;
+}
+
+@media (max-width: 768px) {
+    .detail-panel {
+        width: 100%;
+    }
+    .panel-header {
+        padding: 16px 22px;
+    }
+    .panel-content {
+        padding: 20px;
+    }
+}
 
 /* === Responsivitet === */
 @media (max-width: 1024px) {

--- a/issue-matrix.html
+++ b/issue-matrix.html
@@ -104,6 +104,18 @@
             <!-- Matrisen genereres her av issue-matrix.js -->
         </div>
 
+        <!-- Sidepanel for detaljer om sak -->
+        <div id="matrix-panel-overlay" class="panel-overlay" aria-hidden="true"></div>
+        <aside id="matrix-detail-panel" class="detail-panel" aria-hidden="true" aria-labelledby="matrix-panel-title" role="dialog" aria-modal="true">
+            <div class="panel-header">
+                <h3 id="matrix-panel-title">Saksdetaljer</h3>
+                <button id="matrix-close-panel" class="close-panel-btn" type="button" aria-label="Lukk panelet">&times;</button>
+            </div>
+            <div id="matrix-panel-content" class="panel-content">
+                <div class="loader">Velg en sak for å se detaljer.</div>
+            </div>
+        </aside>
+
 
         <!-- Footer -->
         <footer>


### PR DESCRIPTION
## Summary
- add an off-canvas detail panel to issue-matrix with overlay and accessible controls
- style the matrix issue cells as buttons and provide shared panel styling
- populate the panel with party stances, quotes, and logo links to party profiles when an issue is selected

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4f835f0e4832eac585aa61f39927c