### PR TITLE
Improve representative modal on mobile

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -821,6 +821,9 @@ footer {
 .quote-modal.hover-mode .quote-modal-content {
    padding: 15px 20px; position: fixed; width: auto; max-width: 350px; z-index: 1001;
 }
+body.modal-open {
+   overflow: hidden;
+}
 @keyframes modalFadeIn { from {opacity: 0; transform: translateY(-10px);} to {opacity: 1; transform: translateY(0);} }
 .close-modal {
    color: #aaa; position: absolute; right: 15px; top: 10px; font-size: 28px; font-weight: bold; cursor: pointer; transition: color 0.2s;
@@ -837,6 +840,37 @@ footer {
 .quote-party-title.party-tag-mdg { background-color: #439539; } .quote-party-title.party-tag-pf { background-color: #a04d94; }
 .quote-text {
    font-size: 1rem; line-height: 1.5; color: #333; padding: 12px; background-color: #f8f9fa; border-left: 3px solid var(--kf-purple); margin: 10px 0 0 0; border-radius: 4px; font-style: italic;
+}
+
+#representative-detail-modal .quote-modal-content {
+   max-height: 90vh;
+   overflow-y: auto;
+}
+
+@media (max-width: 768px) {
+   #representative-detail-modal.quote-modal:not(.hover-mode) .quote-modal-content {
+      margin: 0;
+      width: 100%;
+      max-width: none;
+      height: 100%;
+      max-height: none;
+      border-radius: 0;
+      padding: 24px 20px 36px;
+      display: flex;
+      flex-direction: column;
+   }
+
+   #representative-detail-modal .close-modal {
+      top: 18px;
+      right: 22px;
+      font-size: 34px;
+   }
+
+   #representative-detail-modal #representative-detail-content {
+      flex: 1;
+      overflow-y: auto;
+      margin-top: 20px;
+   }
 }
 .no-quote-text {
     font-style: italic;

--- a/js/representatives.js
+++ b/js/representatives.js
@@ -21,6 +21,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const detailPanelContent = detailPanel?.querySelector('.panel-content');
     const modal = document.getElementById('representative-detail-modal');
     const modalContentContainer = document.getElementById('representative-detail-content');
+    const modalContentWrapper = modal?.querySelector('.quote-modal-content');
     const closeModalBtn = document.getElementById('close-representative-modal');
 
     // --- Datainnlasting ---
@@ -98,8 +99,18 @@ document.addEventListener('DOMContentLoaded', () => {
             if (card) handleCardInteraction(card);
         });
 
-        closeModalBtn?.addEventListener('click', () => { if (modal) modal.style.display = 'none'; });
-        modal?.addEventListener('click', (event) => { if (event.target === modal) modal.style.display = 'none'; });
+        closeModalBtn?.addEventListener('click', closeModal);
+        modal?.addEventListener('click', (event) => {
+            if (event.target === modal) {
+                closeModal();
+            }
+        });
+
+        window.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape' && isModalOpen()) {
+                closeModal();
+            }
+        });
 
         resetDetailPanel();
     }
@@ -132,7 +143,7 @@ document.addEventListener('DOMContentLoaded', () => {
     function displayInModal(rep) {
         const partyInfo = partiesMap[rep.partyShorthand];
         modalContentContainer.innerHTML = generateDetailHTML(rep, partyInfo, true);
-        modal.style.display = 'block';
+        openModal();
     }
 
     // =======================================================
@@ -172,6 +183,26 @@ document.addEventListener('DOMContentLoaded', () => {
             currentlySelectedCard.classList.remove('selected-detail');
             currentlySelectedCard = null;
         }
+    }
+
+    function isModalOpen() {
+        return modal && modal.style.display === 'block';
+    }
+
+    function openModal() {
+        if (!modal) return;
+        modal.style.display = 'block';
+        modal.scrollTop = 0;
+        if (modalContentWrapper) {
+            modalContentWrapper.scrollTop = 0;
+        }
+        document.body.classList.add('modal-open');
+    }
+
+    function closeModal() {
+        if (!modal) return;
+        modal.style.display = 'none';
+        document.body.classList.remove('modal-open');
     }
     
     // --- Filtrering og Visning ---


### PR DESCRIPTION
## Summary
- make the representative detail modal manage open and close state with body scroll locking and escape support
- restyle the representative modal on small screens so it fills the viewport and keeps its content accessible

## Testing
- Manual Playwright check of the mobile modal

------
https://chatgpt.com/codex/tasks/task_e_68e5f93fbc1c832e9320c6b9d4e95de8