### PR TITLE
Make representative modal behave as mobile popup

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -821,6 +821,9 @@ footer {
 .quote-modal.hover-mode .quote-modal-content {
    padding: 15px 20px; position: fixed; width: auto; max-width: 350px; z-index: 1001;
 }
+body.modal-open {
+   overflow: hidden;
+}
 @keyframes modalFadeIn { from {opacity: 0; transform: translateY(-10px);} to {opacity: 1; transform: translateY(0);} }
 .close-modal {
    color: #aaa; position: absolute; right: 15px; top: 10px; font-size: 28px; font-weight: bold; cursor: pointer; transition: color 0.2s;
@@ -837,6 +840,54 @@ footer {
 .quote-party-title.party-tag-mdg { background-color: #439539; } .quote-party-title.party-tag-pf { background-color: #a04d94; }
 .quote-text {
    font-size: 1rem; line-height: 1.5; color: #333; padding: 12px; background-color: #f8f9fa; border-left: 3px solid var(--kf-purple); margin: 10px 0 0 0; border-radius: 4px; font-style: italic;
+}
+
+#representative-detail-modal.quote-modal:not(.hover-mode) {
+   align-items: center;
+   justify-content: center;
+   padding: 24px 16px;
+}
+
+#representative-detail-modal .quote-modal-content {
+   width: min(520px, 92vw);
+   max-height: 85vh;
+   display: flex;
+   flex-direction: column;
+   padding: 28px 28px 36px;
+   overflow: hidden;
+}
+
+#representative-detail-modal #representative-detail-content {
+   flex: 1;
+   overflow-y: auto;
+   margin-top: 18px;
+   padding-right: 6px;
+}
+
+#representative-detail-modal .close-modal {
+   top: 20px;
+   right: 24px;
+   font-size: 30px;
+   z-index: 1;
+}
+
+@media (max-width: 768px) {
+   #representative-detail-modal .quote-modal-content {
+      width: min(480px, 96vw);
+      max-height: 88vh;
+      padding: 24px 22px 32px;
+      border-radius: 20px;
+   }
+
+   #representative-detail-modal .close-modal {
+      top: 16px;
+      right: 18px;
+      font-size: 34px;
+   }
+
+   #representative-detail-modal #representative-detail-content {
+      margin-top: 16px;
+   }
 }
 .no-quote-text {
     font-style: italic;

--- a/js/representatives.js
+++ b/js/representatives.js
@@ -21,6 +21,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const detailPanelContent = detailPanel?.querySelector('.panel-content');
     const modal = document.getElementById('representative-detail-modal');
     const modalContentContainer = document.getElementById('representative-detail-content');
+    const modalContentWrapper = modal?.querySelector('.quote-modal-content');
     const closeModalBtn = document.getElementById('close-representative-modal');
 
     // --- Datainnlasting ---
@@ -98,8 +99,18 @@ document.addEventListener('DOMContentLoaded', () => {
             if (card) handleCardInteraction(card);
         });
 
-        closeModalBtn?.addEventListener('click', () => { if (modal) modal.style.display = 'none'; });
-        modal?.addEventListener('click', (event) => { if (event.target === modal) modal.style.display = 'none'; });
+        closeModalBtn?.addEventListener('click', closeModal);
+        modal?.addEventListener('click', (event) => {
+            if (event.target === modal) {
+                closeModal();
+            }
+        });
+
+        window.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape' && isModalOpen()) {
+                closeModal();
+            }
+        });
 
         resetDetailPanel();
     }
@@ -132,7 +143,7 @@ document.addEventListener('DOMContentLoaded', () => {
     function displayInModal(rep) {
         const partyInfo = partiesMap[rep.partyShorthand];
         modalContentContainer.innerHTML = generateDetailHTML(rep, partyInfo, true);
-        modal.style.display = 'block';
+        openModal();
     }
 
     // =======================================================
@@ -172,6 +183,26 @@ document.addEventListener('DOMContentLoaded', () => {
             currentlySelectedCard.classList.remove('selected-detail');
             currentlySelectedCard = null;
         }
+    }
+
+    function isModalOpen() {
+        return modal && modal.style.display === 'flex';
+    }
+
+    function openModal() {
+        if (!modal) return;
+        modal.style.display = 'flex';
+        modal.scrollTop = 0;
+        if (modalContentWrapper) {
+            modalContentWrapper.scrollTop = 0;
+        }
+        document.body.classList.add('modal-open');
+    }
+
+    function closeModal() {
+        if (!modal) return;
+        modal.style.display = 'none';
+        document.body.classList.remove('modal-open');
     }
     
     // --- Filtrering og Visning ---


### PR DESCRIPTION
## Summary
- center the representative detail modal overlay and constrain its dimensions so the content fits comfortably on phones
- update the modal content layout and scrolling so information is immediately visible without relying on the desktop side panel
- switch the modal open state to use flex display to match the new centered layout

## Testing
- Manual Playwright capture of the mobile modal


------
https://chatgpt.com/codex/tasks/task_e_68e5f93fbc1c832e9320c6b9d4e95de8