### PR TITLE
Add committee leadership metadata and UI highlighting

### DIFF
--- a/css/representatives.css
+++ b/css/representatives.css
@@ -106,6 +106,29 @@
     color: #555;
     padding-top: 10px;
     border-top: 1px dashed #eee;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.committee-role-badge {
+    align-self: flex-start;
+    background: linear-gradient(135deg, rgba(111, 44, 145, 0.15), rgba(111, 44, 145, 0.35));
+    color: #4a1d70;
+    font-weight: 600;
+    font-size: 0.85rem;
+    padding: 4px 10px;
+    border-radius: 999px;
+    letter-spacing: 0.01em;
+}
+
+.representative-card.committee-role-highlight {
+    box-shadow: 0 0 0 2px rgba(111, 44, 145, 0.22), 0 2px 5px rgba(0,0,0,0.05);
+}
+
+.representative-card.committee-role-highlight:hover,
+.representative-card.committee-role-highlight.selected-detail {
+    box-shadow: 0 0 0 2px rgba(111, 44, 145, 0.3), 0 6px 15px rgba(0,0,0,0.1);
 }
 
 /* Detail Panel Styling */

--- a/data/representatives.json
+++ b/data/representatives.json
@@ -11,7 +11,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/abid-raja.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=150&e=yVITf1",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Agnes Nærland Viljugrein",
@@ -25,7 +26,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/agnes-naerland-viljugrein.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=22&e=Sr2OOJ",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Aina Stenersen",
@@ -39,7 +41,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/aina-stenersen.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=82&e=UyGaqR",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Aleksander Stokkebø",
@@ -53,7 +56,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/aleksander-stokkebo.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=113&e=FVAFBf",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Alf Erik Andersen",
@@ -67,7 +71,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/alf-erik-andersen.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=57&e=8QyVDi",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": "1. nestleder"
   },
   {
     "name": "Amalie Gunnufsen",
@@ -81,7 +86,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/amalie-gunnufsen.jpeg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=152&e=mzQvwn",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Andreas Bjelland Eriksen",
@@ -95,7 +101,8 @@
     "kfContact": "",
     "imageUrl": "",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=159&e=dgBos4",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Anette Carnarius Elseth",
@@ -109,7 +116,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/annette-carnarius-elseth.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=145&e=xfJIgC",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Anna Irene Molberg",
@@ -123,7 +131,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/anna-molberg.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=34&e=ihiQdC",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Anne Grethe Hauan",
@@ -137,7 +146,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/anne-grethe-hauan.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=7&e=05YH0u",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Anne Hagenborg",
@@ -151,7 +161,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/anne-hagenborg.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=142&e=vMtKuf",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Anne Kristine Linnestad",
@@ -165,7 +176,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/anne-kristine-linnestad.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=12&e=Nkdv2i",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Anne Lise Fredlund",
@@ -179,7 +191,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/anne-lise-gjerstad-fredlund.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=135&e=iWT314",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Anniken Refseth",
@@ -193,7 +206,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/anniken-refseth.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=77&e=ImO2Ge",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Arild Hermstad",
@@ -207,7 +221,8 @@
     "kfContact": "Thomas Axelsen",
     "imageUrl": "images/representatives/arild-hermstad.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=136&e=rCPc4k",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Bengt Fasteraune",
@@ -221,7 +236,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/bengt-fasteraune.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=39&e=La94kb",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Mari Holm Lønseth",
@@ -235,7 +251,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/mari-holm-lonseth.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=1&e=MmAs87",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Bengt Rune Strifeldt",
@@ -249,7 +266,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/bengt-rune-strifeldt.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=133&e=dMaaE2",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": "2. nestleder"
   },
   {
     "name": "Benjamin Jakobsen",
@@ -263,7 +281,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/benjamin-jakobsen.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=116&e=gxfHTj",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Bente Estil",
@@ -277,7 +296,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/bente-estil.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=48&e=wCDsdj",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": "Leder"
   },
   {
     "name": "Bent-Joacim Bentzen",
@@ -291,7 +311,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/bent-joacim-bentzen.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=23&e=qNWpay",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Bjørn Arild Gram",
@@ -305,7 +326,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/bjorn-arild-gram.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=70&e=j6LbAe",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": "2. nestleder"
   },
   {
     "name": "Bjørn Larsen",
@@ -319,7 +341,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/bjorn-larsen.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=72&e=Yz7wRd",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Bjørnar Laabak",
@@ -333,7 +356,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/bjornar-laabak.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=94&e=R7Sqeb",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Bjørnar Moxnes",
@@ -347,7 +371,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/bjornar-moxnes.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=4&e=vGgm3e",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Bjørn-Kristian Svendsrud",
@@ -361,7 +386,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/bjorn-kristian-svendsrud.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=131&e=DyrcvR",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Bård André Hoksrud",
@@ -375,7 +401,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/bard-hoksrud.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=64&e=7wTdLb",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": "Leder"
   },
   {
     "name": "Bård Ludvig Thorheim",
@@ -389,7 +416,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/bard-ludvig-thorheim.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=127&e=QrQXKx",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Dagfinn Henrik Olsen",
@@ -403,7 +431,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/dagfinn-henrik-olsen.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=11&e=jFo9EZ",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Elise Waagen",
@@ -417,7 +446,8 @@
     "kfContact": "Shakeel Rehman",
     "imageUrl": "images/representatives/elise-waagen.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=37&e=uSnoo1",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": "2. nestleder"
   },
   {
     "name": "Erlend Larsen",
@@ -431,7 +461,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/erlend-larsen.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=92&e=iyoDP0",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Erlend Svardal Bøe",
@@ -445,7 +476,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/erlend-svardal-boe.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=146&e=GHoOIm",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": "1. nestleder"
   },
   {
     "name": "Erlend Wiborg",
@@ -459,7 +491,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/erlend-wiborg.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=86&e=jpQovY",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": "1. nestleder"
   },
   {
     "name": "Erling Sande",
@@ -473,7 +506,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/erling-sande.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=66&e=3oCI8e",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Erna Solberg",
@@ -487,7 +521,8 @@
     "kfContact": "Ida Steinsland Lutro",
     "imageUrl": "images/representatives/erna-solberg.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=162&e=WAuT4V",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Even Amandus Røed",
@@ -501,7 +536,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/even-amandus-roed.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=119&e=uaBBMz",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Even Hemstad Eriksen",
@@ -515,7 +551,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/even-eriksen.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=76&e=8OV7Hr",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": "1. nestleder"
   },
   {
     "name": "Farahnaz Bahrami",
@@ -529,7 +566,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/farahnaz-bahrami.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=171&e=X0mVfz",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Farukh Qureshi",
@@ -543,7 +581,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/farukh-qureshi.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=180&e=aYB7PF",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Finn Krokeide",
@@ -557,7 +596,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/finn-krokeide.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=129&e=xvQeU9",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Frank Edvard Sve",
@@ -571,7 +611,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/frank-edvard-sve.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=78&e=ggvh5R",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Frode Jacobsen",
@@ -585,7 +626,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/frode-jacobsen.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=151&e=VyERiX",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Fröya Skjold Sjursæther",
@@ -599,7 +641,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/froya-skjold-sjursaether.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=3&e=VXFmkH",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Geir Inge Lien",
@@ -613,7 +656,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/geir-inge-lien.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=69&e=fea7Pp",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Geir Pollestad",
@@ -627,7 +671,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/geir-pollestad.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=5&e=Iems2V",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Geir-Asbjørn Jørgensen",
@@ -641,7 +686,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/geir-jorgensen.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=107&e=xV63Va",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Grunde Kreken Almeland",
@@ -655,7 +701,8 @@
     "kfContact": "Lars Dahlgren",
     "imageUrl": "images/representatives/grunde-almeland.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=103&e=EVA8MW",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Guri Melby",
@@ -669,7 +716,8 @@
     "kfContact": "Thomas Axelsen",
     "imageUrl": "images/representatives/guri-melby.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=169&e=nT0gmy",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Hanne Beate Stenvaag",
@@ -683,7 +731,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/hanne-beate-stenvaag.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=148&e=zY6aTy",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": "Leder"
   },
   {
     "name": "Hans Andreas Limi",
@@ -697,7 +746,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/hans-andreas-limi.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=138&e=OMM849",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": "1. nestleder"
   },
   {
     "name": "Hans Edvard Askjer",
@@ -711,7 +761,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/hans-edvard-askjer.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=110&e=D9ROmb",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Harry Valderhaug",
@@ -725,7 +776,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/harry-valderhaug.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=71&e=3K6GgC",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Hashim Abdi",
@@ -739,7 +791,8 @@
     "kfContact": "Shakeel Rehman",
     "imageUrl": "images/representatives/hashim-abdi.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=24&e=g3dy0a",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Hege Bae Nyholt",
@@ -753,7 +806,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/hege-bae-nyholt.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=14&e=IFMVJp",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": "2. nestleder"
   },
   {
     "name": "Helge André Njåstad",
@@ -767,7 +821,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/helge-andre-njastad.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=114&e=bZFir4",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Henrik Asheim",
@@ -781,7 +836,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/henrik-asheim.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=87&e=A2bOPy",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Hilde Grande",
@@ -795,7 +851,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/hilde-grande.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=95&e=L6utOh",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Himanshu Gulati",
@@ -809,7 +866,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/himanshu-gulati.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=29&e=RZBlKZ",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Haagen Severin Nilson Poppe",
@@ -823,7 +881,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/haagen-severin-nilson-poppe.avif",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=112&e=kdjoe4",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Ida Lindtveit Røse",
@@ -837,7 +896,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/ida-lindtveit-rose.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=62&e=Y5Anx4",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Ine Eriksen Søreide",
@@ -851,7 +911,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/ine-eriksen-soreide.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=55&e=u0FBAh",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Ingrid Fiskaa",
@@ -865,7 +926,8 @@
     "kfContact": "Shakeel Rehman",
     "imageUrl": "images/representatives/ingrid-fiskaa.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=124&e=DmvVTt",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Ingrid Liland",
@@ -879,7 +941,8 @@
     "kfContact": "Lars Dahlgren",
     "imageUrl": "images/representatives/ingrid-liland.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=167&e=1l4i5B",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Isak Veierud Busch",
@@ -893,7 +956,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/isak-verierud-busch.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=25&e=8jlKnu",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Joakim Myklebost Tangen",
@@ -907,7 +971,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/joakim-myklebost-tangen.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=123&e=wmtjyG",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Joel Ystebø",
@@ -921,7 +986,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/joel-ystebo.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=30&e=T8qh10",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Jon Engen-Helgheim",
@@ -935,7 +1001,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/jon-engen-helgheim.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=106&e=bBdlHJ",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": "Leder"
   },
   {
     "name": "Jonas Andersen Sayed",
@@ -949,7 +1016,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/jonas-andersen-sayed.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=36&e=azKY68",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Jone Blikra",
@@ -963,7 +1031,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/jone-blikra.jpg",
     "profileUrl": "",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Jørgen Kristiansen",
@@ -977,7 +1046,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/jorgen-kristiansen.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=98&e=eX1auz",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Jorunn Gleditsch Lossius",
@@ -991,7 +1061,8 @@
     "kfContact": "Lars Dahlgren",
     "imageUrl": "images/representatives/jorunn-gleditsch-lossius.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=2&e=XZDcqd",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": "1. nestleder"
   },
   {
     "name": "Julia Brännström Nordtug",
@@ -1005,7 +1076,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/julia-brannstrom-nordtug.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=33&e=rJbtN5",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Julia Eikeland",
@@ -1019,7 +1091,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/julia-eikeland.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=26&e=yI2i08",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Julie Estdahl Stuestøl",
@@ -1033,7 +1106,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/julie-estedahl-stuestol.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=102&e=r8uu5C",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": "2. nestleder"
   },
   {
     "name": "June Trengereid Gruer",
@@ -1047,7 +1121,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/june-trengereid-gruer.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=183&e=NdyRo4",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Kai Steffen Østensen",
@@ -1061,7 +1136,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/kai-steffen-ostensen.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=28&e=Rnp0Ko",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Kamzy Gunaratnam",
@@ -1075,7 +1151,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/kamzy-gunaratnam.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=147&e=CAJULD",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": "1. nestleder"
   },
   {
     "name": "Kari Baadstrand Sandnes",
@@ -1089,7 +1166,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/kari-baadstrand-sandnes.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=178&e=xz0kfl",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Kari Sofie Bjørnsen",
@@ -1103,7 +1181,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/kari-sofie-bjornsen.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=49&e=YKhjzz",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Kathy Lie",
@@ -1117,7 +1196,8 @@
     "kfContact": "Lars Dahlgren",
     "imageUrl": "images/representatives/kathy-lie.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=68&e=dMfIgR",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Kirsti Bergstø",
@@ -1131,7 +1211,8 @@
     "kfContact": "Thomas Axelsen",
     "imageUrl": "images/representatives/kirsti-bergsto.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=105&e=zOMnC3",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Kjersti Toppe",
@@ -1145,7 +1226,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/kjersti-toppe.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=6&e=TJhPja",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": "Leder"
   },
   {
     "name": "Konstanse Marie Alvær",
@@ -1159,7 +1241,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/marie-konstanse-alvaer.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=175&e=hnXKOx",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Kristian August Eilertsen",
@@ -1173,7 +1256,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/kristian-august-eilertsen.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=53&e=FchUu4",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Kristine L. Solli",
@@ -1187,7 +1271,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/kristine-lofshus-solli.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=16&e=q2vcvw",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Kristoffer Sivertsen",
@@ -1201,7 +1286,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/kristoffer-sivertsen.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=40&e=Qi3Oq3",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Lars Haltbrekken",
@@ -1215,7 +1301,8 @@
     "kfContact": "Lars Dahlgren",
     "imageUrl": "images/representatives/lars-haltbrekken.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=74&e=ngQKf6",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": "2. nestleder"
   },
   {
     "name": "Lars Terje Høiendahl Rem",
@@ -1229,7 +1316,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/lars-rem.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=35&e=8PdIV4",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Lill Harriet Sandaune",
@@ -1243,7 +1331,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/lill-harriet-sandaune.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=75&e=TmoJ94",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Linda Merkesdal",
@@ -1257,7 +1346,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/linda-monsen-merkesdal.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=121&e=ndJQre",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Line Marlene Haugen",
@@ -1271,7 +1361,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/line-marlene-haugen.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=109&e=AKxs5a",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Lise Selnes",
@@ -1285,7 +1376,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/lise-selnes.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=51&e=7dlFRG",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Liv Thon Gustavsen",
@@ -1299,7 +1391,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/liv-gustavsen.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=97&e=3baqoq",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Mahmoud Farahmand",
@@ -1313,7 +1406,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/magmoud-farahmand.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=8&e=RP0iPS",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Mani Hussaini",
@@ -1327,7 +1421,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/mani-hussaini.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=65&e=o8Is4p",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": "Leder"
   },
   {
     "name": "Maren Grøthe",
@@ -1341,7 +1436,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/maren-grothe.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=122&e=ct2cS7",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Margret Hagerup",
@@ -1355,7 +1451,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/margret-hagerup.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=41&e=kcYku9",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Maria-Karine Aasen-Svensrud",
@@ -1369,7 +1466,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/maria-aasen-svensrud.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=99&e=Y3jqHa",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Marian Hussein",
@@ -1383,7 +1481,8 @@
     "kfContact": "Shakeel Rehman",
     "imageUrl": "images/representatives/marian-hussein.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=13&e=hAtK9O",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": "Leder"
   },
   {
     "name": "Marie Sneve Martinussen",
@@ -1397,7 +1496,8 @@
     "kfContact": "Thomas Axelsen",
     "imageUrl": "images/representatives/marie-sneve-martinussen.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=21&e=asGbqS",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Marius Arion Nilsen",
@@ -1411,7 +1511,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/marius-arion-nilsen.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=118&e=NPrshk",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Marius Langballe Dalin",
@@ -1425,7 +1526,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/marius-langballe-dalin.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=47&e=PHpZ6A",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Marthe Hammer",
@@ -1439,7 +1541,8 @@
     "kfContact": "Gina Knutson Barstad",
     "imageUrl": "images/representatives/marthe-hammer.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=132&e=GXrn3n",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Martin Virkesdal Jonsterhaug",
@@ -1453,7 +1556,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/martin-virkesdal-jonsterhaug.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=73&e=8qzWtL",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Masud Gharahkhani",
@@ -1467,7 +1571,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/masud-gharahkhani.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=157&e=Q9E2gV",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Mathilde Tybring-Gjedde",
@@ -1481,7 +1586,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/mathilde-tybring-gjedde.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=111&e=wYekI1",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": "Leder"
   },
   {
     "name": "Mats Henriksen",
@@ -1495,7 +1601,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/mats-henriksen.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=91&e=pdjlu4",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "May Helen Hetland Ervik",
@@ -1509,7 +1616,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/may-helen-hetland-ervik.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=149&e=KRRJuk",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Mímir Kristjánsson",
@@ -1523,7 +1631,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/mimir-kristjansson.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=104&e=sVSb6A",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Mirell Høyer-Berntsen",
@@ -1537,7 +1646,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/mirell-hoyer-berntsen.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=15&e=hWq3fm",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Mona Nilsen",
@@ -1551,7 +1661,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/mona-nilsen.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=130&e=H2l6gg",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Monica Molvær",
@@ -1565,7 +1676,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/monica-molvaer.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=125&e=upDh7M",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Monica Nielsen",
@@ -1579,7 +1691,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/monica-nielsen.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=182&e=5guceH",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Morgan Engebretsen Langfeldt",
@@ -1593,7 +1706,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/morgan-langfeldt.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=67&e=ESSSTH",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Morten Kolbjørnsen",
@@ -1607,7 +1721,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/morten-kolbjornsen.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=143&e=KiGEK2",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Morten Stordalen",
@@ -1621,7 +1736,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/morten-stordalen.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=93&e=xdSzjv",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Mudassar Hussain Kapur",
@@ -1635,7 +1751,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/mudassar-kapur.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=163&e=Tcwg32",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Nikolai Astrup",
@@ -1649,7 +1766,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/nikolai-astrup.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=164&e=KhzgiF",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Nils-Ole Foshaug",
@@ -1663,7 +1781,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/nils-ole-foshaug.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=144&e=LQdizR",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Oda Indgaard",
@@ -1677,7 +1796,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/oda-indgaard.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=42&e=Qcd3zc",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Ove Bernt Trellevik",
@@ -1691,7 +1811,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/ove-trellevik.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=46&e=7Xs0s4",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": "2. nestleder"
   },
   {
     "name": "Per Vidar Kjølmoen",
@@ -1705,7 +1826,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/per-vidar-kjolmoen.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=83&e=4UaTKg",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Per-Willy Amundsen",
@@ -1719,7 +1841,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/pre-willy-amundsen.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=161&e=kq7m3M",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": "Leder"
   },
   {
     "name": "Peter Christian Frølich",
@@ -1733,7 +1856,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/peter-frolich.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=17&e=Azmic2",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Pål Morten Borgli",
@@ -1747,7 +1871,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/pal-morten-borgli.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=84&e=7tnwlC",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Ragnhild Synnøve Bergheim",
@@ -1761,7 +1886,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/ragnhild-bergheim.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=9&e=uBtgSG",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Remi Alexander Sølvberg",
@@ -1775,7 +1901,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/remi-solvberg.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=50&e=ueH53e",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Rikard Spets",
@@ -1789,7 +1916,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/rikard-spets.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=63&e=trB8nD",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Ronny Aukrust",
@@ -1803,7 +1931,8 @@
     "kfContact": "Shakeel Rehman",
     "imageUrl": "images/representatives/ronny-aukrust.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=170&e=8cz6Qa",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Rune Bakervik",
@@ -1817,7 +1946,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/rune-bakervik.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=140&e=Umqh61",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Rune Midtun",
@@ -1831,7 +1961,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/rune-midtun.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=153&e=hXje7w",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Rune Støstad",
@@ -1845,7 +1976,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/rune-stostad.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=88&e=r5NRbH",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": "Leder"
   },
   {
     "name": "Ruth Mariann Hop",
@@ -1859,7 +1991,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/ruth-mariann-hop.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=120&e=A9I4xu",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Seher Aydar",
@@ -1873,7 +2006,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/seher-aydar.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=108&e=ZYLRs7",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Sigurd Kvammen Rafaelsen",
@@ -1887,7 +2021,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/sigurd-kvammen-rafaelsen.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=18&e=nifcAz",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": "2. nestleder"
   },
   {
     "name": "Silje Hjemdal",
@@ -1901,7 +2036,8 @@
     "kfContact": "Lars Dahlgren",
     "imageUrl": "images/representatives/silje-hjemdal.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=89&e=fQAKc6",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": "2. nestleder"
   },
   {
     "name": "Simen Velle",
@@ -1915,7 +2051,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/simen-velle.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=10&e=pD0hiB",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Siren Julianne Jensen",
@@ -1929,7 +2066,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/siren-julianne-jensen.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=166&e=fYbY30",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Sofie Marhaug",
@@ -1943,7 +2081,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/sofie-marhaug.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=128&e=5C6Duq",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Solveig Vestenfor",
@@ -1957,7 +2096,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/solveig-vestenfor.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=141&e=3x5vCu",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Solveig Vitanza",
@@ -1971,7 +2111,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/solveig-vitanza.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=137&e=UZ9oLv",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Stian Storbukås",
@@ -1985,7 +2126,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/stian-storbukaas.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=96&e=If2nRD",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Stig Atle Abrahamsen",
@@ -1999,7 +2141,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/stig-atle-abrahamsen.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=58&e=Hm9XH7",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Stig Even Søvik Lillestøl",
@@ -2013,7 +2156,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/stig-even-lillestol.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=38&e=5qqah5",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Sunniva Holmås Eidsvoll",
@@ -2027,7 +2171,8 @@
     "kfContact": "Lars Dahlgren",
     "imageUrl": "images/representatives/sunniva-holmas-eidsvoll.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=154&e=fBW9Tg",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Sverre Myrli",
@@ -2041,7 +2186,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/sverre-myrli.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=100&e=rO5XvO",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": "1. nestleder"
   },
   {
     "name": "Sylvi Listhaug",
@@ -2055,7 +2201,8 @@
     "kfContact": "Thomas Axelsen",
     "imageUrl": "images/representatives/sylvi-listhaug.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=45&e=TpPy8P",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Tage Pettersen",
@@ -2069,7 +2216,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/tage-pettersen.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=56&e=wqCQ4q",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Tobias Hangaard Linge",
@@ -2083,7 +2231,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/tobias-hangaard-linge.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=172&e=IpvAUi",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Tom Einar Karlsen",
@@ -2097,7 +2246,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/tom-einar-karlsen.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=181&e=eX5cZn",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Tom Staahle",
@@ -2111,7 +2261,8 @@
     "kfContact": "Shakeel Rehman",
     "imageUrl": "images/representatives/tom-staahle.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=60&e=yVRuhm",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Tone Wilhelmsen Trøen",
@@ -2125,7 +2276,8 @@
     "kfContact": "Thomas Axelsen",
     "imageUrl": "images/representatives/tone-wilhelmsen-troen.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=117&e=r4q5aq",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Tonje Brenna",
@@ -2139,7 +2291,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/tonje-brenna.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=32&e=FhYY3k",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Tor Andre Johnsen",
@@ -2153,7 +2306,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/tor-andre-johnsen.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=85&e=wV0lxl",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Tor Mikkel Wara",
@@ -2167,7 +2321,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/tor-mikkel-wara.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=79&e=rdvBQ4",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": "1. nestleder"
   },
   {
     "name": "Torbjørn Vereide",
@@ -2181,7 +2336,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/torbjorn-vereide.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=160&e=zKYg4s",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Trine Lise Sundnes",
@@ -2195,7 +2351,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/trine-lise-sundnes.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=179&e=E3Ywxk",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Trond Giske",
@@ -2209,7 +2366,8 @@
     "kfContact": "Shakeel Rehman",
     "imageUrl": "images/representatives/trond-giske.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=43&e=K4ZPg7",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Trond Helleland",
@@ -2223,7 +2381,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/trond-helleland.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=101&e=G14syP",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": "2. nestleder"
   },
   {
     "name": "Truls Vasvik",
@@ -2237,7 +2396,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/truls-vasvik.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=134&e=lYfjrZ",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": "2. nestleder"
   },
   {
     "name": "Trygve Magnus Slagsvold Vedum",
@@ -2251,7 +2411,8 @@
     "kfContact": "Thomas Axelsen",
     "imageUrl": "images/representatives/trygve-slagsvold-vedum.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=168&e=TO0AGU",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Tuva Moflag",
@@ -2265,7 +2426,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/tuva-moflag.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=155&e=lyIMiL",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": "Leder"
   },
   {
     "name": "Une Aina Bastholm",
@@ -2279,7 +2441,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/une-bastholm.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=165&e=uX33iV",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": "1. nestleder"
   },
   {
     "name": "Vebjørn Gorseth",
@@ -2293,7 +2456,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/vebjorn-gorseth.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=20&e=0sXo6S",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Øystein Mathisen",
@@ -2307,7 +2471,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/oystein-mathisen.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=90&e=RI57ag",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Morten Sandanger",
@@ -2321,7 +2486,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/morten-sandanger.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=27&e=YaHeMF",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Morten Wold",
@@ -2335,7 +2501,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/morten-wold.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=59&e=Px6Qcl",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Solveig Vik",
@@ -2349,7 +2516,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/solveig-vik.jpg",
     "profileUrl": "",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   },
   {
     "name": "Tellef Inge Mørland",
@@ -2363,7 +2531,8 @@
     "kfContact": "",
     "imageUrl": "images/representatives/tellef-inge-morland.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=156&e=BCXJdf",
-    "gender": "M"
+    "gender": "M",
+    "committeeRole": ""
   },
   {
     "name": "Åse Kristin Ask Bakke",
@@ -2377,6 +2546,7 @@
     "kfContact": "",
     "imageUrl": "images/representatives/ase-kristin-ask-bakke.jpg",
     "profileUrl": "https://kreftforening-my.sharepoint.com/personal/lars_dahlgren_kreftforeningen_no/Lists/Stortinget%2020252029/DispForm.aspx?ID=31&e=L4J4sd",
-    "gender": "K"
+    "gender": "K",
+    "committeeRole": ""
   }
 ]


### PR DESCRIPTION
## Summary
- add a `committeeRole` field to every representative and populate current committee leaders and nest leaders
- show the committee role on representative cards and detail panels while keeping committee grouping sorted by leadership priority
- highlight committee leaders and nest leaders when viewing representatives grouped by committee

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e6851f5c44832ea6007aaef416e984